### PR TITLE
Auto-detect keyboard layout via libxkbcommon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@
 
 CC = gcc
 CFLAGS = -O2 -Wall -Wextra
+XKB_CFLAGS = $(shell pkg-config --cflags xkbcommon)
+XKB_LIBS = $(shell pkg-config --libs xkbcommon)
 PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 all: xhispertool test
 
 xhispertool: xhispertool.c
-	$(CC) $(CFLAGS) xhispertool.c -o xhispertool
+	$(CC) $(CFLAGS) $(XKB_CFLAGS) xhispertool.c -o xhispertool $(XKB_LIBS)
 	ln -sf xhispertool xhispertoold
 
 test: test.c

--- a/README.md
+++ b/README.md
@@ -12,30 +12,30 @@ Dictation at cursor for Linux.
 
 <details>
 <summary>Arch Linux / Manjaro</summary>
-<pre><code>sudo pacman -S pipewire jq curl ffmpeg gcc</code></pre>
+<pre><code>sudo pacman -S pipewire jq curl ffmpeg gcc libxkbcommon</code></pre>
 </details>
 
 <details>
 <summary>Debian / Ubuntu / Linux Mint</summary>
 <pre><code>sudo apt update
-sudo apt install pipewire jq curl ffmpeg gcc</code></pre>
+sudo apt install pipewire jq curl ffmpeg gcc libxkbcommon-dev</code></pre>
 </details>
 
 <details>
 <summary>Fedora / RHEL / AlmaLinux / Rocky</summary>
-<pre><code>sudo dnf install -y pipewire pipewire-utils jq curl ffmpeg gcc</code></pre>
+<pre><code>sudo dnf install -y pipewire pipewire-utils jq curl ffmpeg gcc libxkbcommon-devel</code></pre>
 </details>
 
 <details>
 <summary>OpenSUSE (Leap / Tumbleweed)</summary>
 <pre><code>sudo zypper refresh
-sudo zypper install pipewire jq curl ffmpeg gcc</code></pre>
+sudo zypper install pipewire jq curl ffmpeg gcc libxkbcommon-devel</code></pre>
 </details>
 
 <details>
 <summary>Void Linux</summary>
 <pre><code>sudo xbps-install -S
-sudo xbps-install pipewire jq curl ffmpeg gcc</code></pre>
+sudo xbps-install pipewire jq curl ffmpeg gcc libxkbcommon-devel</code></pre>
 </details>
 
 **Note:** `wl-clipboard` (Wayland) or `xclip` (X11) required for non-ASCII but usually pre-installed.
@@ -143,9 +143,19 @@ The transcription will be typed at your cursor position.
 xhisper --log
 ```
 
-**Non-QWERTY layouts:**
+**Keyboard layouts:**
 
-For non-QWERTY layouts (e.g. Dvorak, International), set up an input switch key to QWERTY (e.g. rightalt). Then instead of binding to `xhisper`, bind to:
+xhisper auto-detects your keyboard layout via `libxkbcommon` at startup, so QWERTY variants (Italian, German, French, Spanish, etc.) work out of the box with correct punctuation.
+
+If auto-detection picks the wrong layout, set it explicitly in `~/.config/xhisper/xhisperrc`:
+```
+keyboard-layout : it
+```
+Then restart the daemon: `pkill xhispertoold`
+
+**Non-QWERTY layouts (Dvorak, Colemak, etc.):**
+
+For fundamentally different layouts, set up an input switch key to QWERTY (e.g. rightalt). Then instead of binding to `xhisper`, bind to:
 ```sh
 xhisper --<your-input-switch-key>
 ```

--- a/default_xhisperrc
+++ b/default_xhisperrc
@@ -14,3 +14,10 @@ non-ascii-default-delay : 0.025
 silence-threshold  : -50
 silence-percentage : 95
 
+# Keyboard Layout (for correct punctuation typing):
+# Auto-detected from XKB_DEFAULT_LAYOUT if empty.
+# Set to your XKB layout code if auto-detection picks the wrong layout.
+# Changing this requires restarting the daemon (pkill xhispertoold).
+keyboard-layout  : ""
+keyboard-variant : ""
+

--- a/xhisper.sh
+++ b/xhisper.sh
@@ -72,6 +72,8 @@ silence_threshold=-50
 silence_percentage=95
 non_ascii_initial_delay=0.1
 non_ascii_default_delay=0.025
+keyboard_layout=""
+keyboard_variant=""
 
 CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/xhisper/xhisperrc"
 
@@ -92,13 +94,29 @@ if [ -f "$CONFIG_FILE" ]; then
       silence-percentage) silence_percentage="$value" ;;
       non-ascii-initial-delay) non_ascii_initial_delay="$value" ;;
       non-ascii-default-delay) non_ascii_default_delay="$value" ;;
+      keyboard-layout) keyboard_layout="$value" ;;
+      keyboard-variant) keyboard_variant="$value" ;;
     esac
   done < "$CONFIG_FILE"
 fi
 
+# Auto-detect keyboard layout if not explicitly configured
+if [ -z "$keyboard_layout" ]; then
+    if [ -n "$XKB_DEFAULT_LAYOUT" ]; then
+        keyboard_layout="$XKB_DEFAULT_LAYOUT"
+    elif command -v localectl &>/dev/null; then
+        keyboard_layout=$(localectl status 2>/dev/null | grep "X11 Layout" | awk '{print $3}')
+    elif [ -f /etc/default/keyboard ]; then
+        keyboard_layout=$(. /etc/default/keyboard 2>/dev/null && echo "$XKBLAYOUT")
+    fi
+fi
+
 # Auto-start daemon if not running
 if ! pgrep -x xhispertoold > /dev/null; then
-    "$XHISPERTOOLD" 2>> /tmp/xhispertoold.log &
+    DAEMON_ARGS=""
+    [ -n "$keyboard_layout" ] && DAEMON_ARGS="$DAEMON_ARGS --layout $keyboard_layout"
+    [ -n "$keyboard_variant" ] && DAEMON_ARGS="$DAEMON_ARGS --variant $keyboard_variant"
+    "$XHISPERTOOLD" $DAEMON_ARGS 2>> /tmp/xhispertoold.log &
     sleep 1  # Give daemon time to start
 
     # Verify daemon started successfully

--- a/xhispertool.c
+++ b/xhispertool.c
@@ -1,6 +1,9 @@
 /*
  * xhisper - Whisper for Linux
  * Combined daemon and client for text input via uinput
+ *
+ * Uses libxkbcommon to auto-detect the active keyboard layout at startup,
+ * so punctuation is typed correctly regardless of layout (US, IT, DE, etc.).
  */
 
 #include <stdio.h>
@@ -14,6 +17,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <linux/uinput.h>
+#include <xkbcommon/xkbcommon.h>
+
 #define KEY_LEFTCTRL 29
 #define KEY_RIGHTCTRL 97
 #define KEY_LEFTALT 56
@@ -22,102 +27,99 @@
 #define KEY_RIGHTSHIFT 54
 #define KEY_LEFTMETA 125
 #define KEY_V 47
-#define FLAG_UPPERCASE 0x80000000
 
-// Function prototypes
+#define MOD_SHIFT 0x01
+#define MOD_ALTGR 0x02
+#define UNMAPPED  0xFFFF
+
+struct char_mapping {
+    uint16_t keycode;
+    uint8_t  modifiers;
+};
+
+static struct char_mapping char_map[128];
+static int fd_uinput = -1;
+static int fd_socket = -1;
+
 void cleanup(void);
 void emit(int type, int code, int val);
 void do_paste(void);
 void type_char(unsigned char c);
 void do_backspace(void);
 void do_key(int keycode);
+int build_char_map(const char *layout, const char *variant);
 int setup_uinput(void);
 int setup_socket(void);
-int run_daemon(void);
+int run_daemon(const char *layout, const char *variant);
 void show_usage(void);
 int run_client(int argc, char *argv[]);
 
-// ASCII to Linux keycode mapping for US QWERTY layout
-// Independently derived from:
-// - ASCII character set specification (characters 0-127)
-// - Linux input-event-codes.h KEY_* constants
-// - US QWERTY keyboard physical layout
-// Each entry maps an ASCII code to either:
-//   -1 (unmapped/unsupported)
-//   KEY_* constant for unshifted characters
-//   KEY_* | FLAG_UPPERCASE for shifted characters
-static const int32_t ascii2keycode_map[128] = {
-	// Control characters (0x00-0x1f): mostly unmapped except tab and enter
-	-1,-1,-1,-1,-1,-1,-1,-1,  // 0x00-0x07
-	-1,KEY_TAB,KEY_ENTER,-1,-1,-1,-1,-1,  // 0x08-0x0f (tab=0x09, enter=0x0a)
-	-1,-1,-1,-1,-1,-1,-1,-1,  // 0x10-0x17
-	-1,-1,-1,-1,-1,-1,-1,-1,  // 0x18-0x1f
+int build_char_map(const char *layout, const char *variant) {
+    for (int i = 0; i < 128; i++) {
+        char_map[i].keycode = UNMAPPED;
+        char_map[i].modifiers = 0;
+    }
 
-	// Printable characters (0x20-0x7e)
-	// Space and symbols (0x20-0x2f)
-	KEY_SPACE,                      // 0x20 ' '
-	KEY_1|FLAG_UPPERCASE,           // 0x21 '!' (shift+1)
-	KEY_APOSTROPHE|FLAG_UPPERCASE,  // 0x22 '"' (shift+')
-	KEY_3|FLAG_UPPERCASE,           // 0x23 '#' (shift+3)
-	KEY_4|FLAG_UPPERCASE,           // 0x24 '$' (shift+4)
-	KEY_5|FLAG_UPPERCASE,           // 0x25 '%' (shift+5)
-	KEY_7|FLAG_UPPERCASE,           // 0x26 '&' (shift+7)
-	KEY_APOSTROPHE,                 // 0x27 '''
-	KEY_9|FLAG_UPPERCASE,           // 0x28 '(' (shift+9)
-	KEY_0|FLAG_UPPERCASE,           // 0x29 ')' (shift+0)
-	KEY_8|FLAG_UPPERCASE,           // 0x2a '*' (shift+8)
-	KEY_EQUAL|FLAG_UPPERCASE,       // 0x2b '+' (shift+=)
-	KEY_COMMA,                      // 0x2c ','
-	KEY_MINUS,                      // 0x2d '-'
-	KEY_DOT,                        // 0x2e '.'
-	KEY_SLASH,                      // 0x2f '/'
+    struct xkb_context *ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    if (!ctx) {
+        fprintf(stderr, "failed to create xkb context\n");
+        return -1;
+    }
 
-	// Digits (0x30-0x39)
-	KEY_0,KEY_1,KEY_2,KEY_3,KEY_4,KEY_5,KEY_6,KEY_7,KEY_8,KEY_9,
+    struct xkb_rule_names names = {0};
+    if (layout) names.layout = layout;
+    if (variant) names.variant = variant;
 
-	// More symbols (0x3a-0x40)
-	KEY_SEMICOLON|FLAG_UPPERCASE,   // 0x3a ':' (shift+;)
-	KEY_SEMICOLON,                  // 0x3b ';'
-	KEY_COMMA|FLAG_UPPERCASE,       // 0x3c '<' (shift+,)
-	KEY_EQUAL,                      // 0x3d '='
-	KEY_DOT|FLAG_UPPERCASE,         // 0x3e '>' (shift+.)
-	KEY_SLASH|FLAG_UPPERCASE,       // 0x3f '?' (shift+/)
-	KEY_2|FLAG_UPPERCASE,           // 0x40 '@' (shift+2)
+    struct xkb_keymap *keymap = xkb_keymap_new_from_names(
+        ctx, &names, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    if (!keymap) {
+        fprintf(stderr, "failed to create xkb keymap");
+        if (layout) fprintf(stderr, " for layout '%s'", layout);
+        fprintf(stderr, "\n");
+        xkb_context_unref(ctx);
+        return -1;
+    }
 
-	// Uppercase letters (0x41-0x5a): A-Z
-	KEY_A|FLAG_UPPERCASE,KEY_B|FLAG_UPPERCASE,KEY_C|FLAG_UPPERCASE,KEY_D|FLAG_UPPERCASE,
-	KEY_E|FLAG_UPPERCASE,KEY_F|FLAG_UPPERCASE,KEY_G|FLAG_UPPERCASE,KEY_H|FLAG_UPPERCASE,
-	KEY_I|FLAG_UPPERCASE,KEY_J|FLAG_UPPERCASE,KEY_K|FLAG_UPPERCASE,KEY_L|FLAG_UPPERCASE,
-	KEY_M|FLAG_UPPERCASE,KEY_N|FLAG_UPPERCASE,KEY_O|FLAG_UPPERCASE,KEY_P|FLAG_UPPERCASE,
-	KEY_Q|FLAG_UPPERCASE,KEY_R|FLAG_UPPERCASE,KEY_S|FLAG_UPPERCASE,KEY_T|FLAG_UPPERCASE,
-	KEY_U|FLAG_UPPERCASE,KEY_V|FLAG_UPPERCASE,KEY_W|FLAG_UPPERCASE,KEY_X|FLAG_UPPERCASE,
-	KEY_Y|FLAG_UPPERCASE,KEY_Z|FLAG_UPPERCASE,
+    xkb_keycode_t min_kc = xkb_keymap_min_keycode(keymap);
+    xkb_keycode_t max_kc = xkb_keymap_max_keycode(keymap);
 
-	// Brackets and symbols (0x5b-0x60)
-	KEY_LEFTBRACE,                  // 0x5b '['
-	KEY_BACKSLASH,                  // 0x5c '\'
-	KEY_RIGHTBRACE,                 // 0x5d ']'
-	KEY_6|FLAG_UPPERCASE,           // 0x5e '^' (shift+6)
-	KEY_MINUS|FLAG_UPPERCASE,       // 0x5f '_' (shift+-)
-	KEY_GRAVE,                      // 0x60 '`'
+    for (xkb_keycode_t kc = min_kc; kc <= max_kc; kc++) {
+        if (xkb_keymap_num_layouts_for_key(keymap, kc) == 0)
+            continue;
 
-	// Lowercase letters (0x61-0x7a): a-z
-	KEY_A,KEY_B,KEY_C,KEY_D,KEY_E,KEY_F,KEY_G,KEY_H,
-	KEY_I,KEY_J,KEY_K,KEY_L,KEY_M,KEY_N,KEY_O,KEY_P,
-	KEY_Q,KEY_R,KEY_S,KEY_T,KEY_U,KEY_V,KEY_W,KEY_X,
-	KEY_Y,KEY_Z,
+        int num_levels = xkb_keymap_num_levels_for_key(keymap, kc, 0);
+        for (int level = 0; level < num_levels && level < 4; level++) {
+            const xkb_keysym_t *syms;
+            int num_syms = xkb_keymap_key_get_syms_by_level(
+                keymap, kc, 0, level, &syms);
 
-	// Final symbols (0x7b-0x7e)
-	KEY_LEFTBRACE|FLAG_UPPERCASE,   // 0x7b '{' (shift+[)
-	KEY_BACKSLASH|FLAG_UPPERCASE,   // 0x7c '|' (shift+\)
-	KEY_RIGHTBRACE|FLAG_UPPERCASE,  // 0x7d '}' (shift+])
-	KEY_GRAVE|FLAG_UPPERCASE,       // 0x7e '~' (shift+`)
+            for (int s = 0; s < num_syms; s++) {
+                uint32_t cp = xkb_keysym_to_utf32(syms[s]);
+                if (cp == 0 || cp >= 128) continue;
+                if (char_map[cp].keycode != UNMAPPED) continue;
 
-	-1  // 0x7f DEL (unmapped)
-};
+                uint8_t mods = 0;
+                if (level == 1) mods = MOD_SHIFT;
+                else if (level == 2) mods = MOD_ALTGR;
+                else if (level == 3) mods = MOD_SHIFT | MOD_ALTGR;
 
-static int fd_uinput = -1;
-static int fd_socket = -1;
+                char_map[cp].keycode = kc - 8; // XKB keycode → evdev keycode
+                char_map[cp].modifiers = mods;
+            }
+        }
+    }
+
+    printf("xhispertoold: keymap loaded");
+    if (layout)  printf(" (layout: %s", layout);
+    if (variant) printf(", variant: %s", variant);
+    if (layout)  printf(")");
+    if (!layout) printf(" (auto-detected from XKB_DEFAULT_LAYOUT or system default)");
+    printf("\n");
+
+    xkb_keymap_unref(keymap);
+    xkb_context_unref(ctx);
+    return 0;
+}
 
 void cleanup() {
     if (fd_uinput >= 0) {
@@ -154,14 +156,18 @@ void do_paste() {
 
 void type_char(unsigned char c) {
     if (c >= 128) return;
+    if (char_map[c].keycode == UNMAPPED) return;
 
-    int32_t kdef = ascii2keycode_map[c];
-    if (kdef == -1) return;
+    uint16_t keycode = char_map[c].keycode;
+    uint8_t mods = char_map[c].modifiers;
 
-    uint16_t keycode = kdef & 0xffff;
-
-    if (kdef & FLAG_UPPERCASE) {
+    if (mods & MOD_SHIFT) {
         emit(EV_KEY, KEY_LEFTSHIFT, 1);
+        emit(EV_SYN, SYN_REPORT, 0);
+        usleep(2000);
+    }
+    if (mods & MOD_ALTGR) {
+        emit(EV_KEY, KEY_RIGHTALT, 1);
         emit(EV_SYN, SYN_REPORT, 0);
         usleep(2000);
     }
@@ -174,7 +180,11 @@ void type_char(unsigned char c) {
     emit(EV_SYN, SYN_REPORT, 0);
     usleep(2000);
 
-    if (kdef & FLAG_UPPERCASE) {
+    if (mods & MOD_ALTGR) {
+        emit(EV_KEY, KEY_RIGHTALT, 0);
+        emit(EV_SYN, SYN_REPORT, 0);
+    }
+    if (mods & MOD_SHIFT) {
         emit(EV_KEY, KEY_LEFTSHIFT, 0);
         emit(EV_SYN, SYN_REPORT, 0);
     }
@@ -205,32 +215,13 @@ int setup_uinput() {
 
     ioctl(fd_uinput, UI_SET_EVBIT, EV_KEY);
 
-    // Register letters
-    for (int i = KEY_Q; i <= KEY_P; i++) ioctl(fd_uinput, UI_SET_KEYBIT, i);
-    for (int i = KEY_A; i <= KEY_L; i++) ioctl(fd_uinput, UI_SET_KEYBIT, i);
-    for (int i = KEY_Z; i <= KEY_M; i++) ioctl(fd_uinput, UI_SET_KEYBIT, i);
+    // Register all keycodes discovered in char_map
+    for (int i = 0; i < 128; i++) {
+        if (char_map[i].keycode != UNMAPPED)
+            ioctl(fd_uinput, UI_SET_KEYBIT, char_map[i].keycode);
+    }
 
-    // Register numbers
-    for (int i = KEY_1; i <= KEY_0; i++) ioctl(fd_uinput, UI_SET_KEYBIT, i);
-
-    // Register special keys
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_SPACE);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_MINUS);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_EQUAL);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_LEFTBRACE);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_RIGHTBRACE);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_SEMICOLON);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_APOSTROPHE);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_GRAVE);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_BACKSLASH);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_COMMA);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_DOT);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_SLASH);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_TAB);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_ENTER);
-    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_BACKSPACE);
-
-    // Register modifiers
+    // Modifiers and special keys (needed for paste, backspace, wrap keys)
     ioctl(fd_uinput, UI_SET_KEYBIT, KEY_LEFTCTRL);
     ioctl(fd_uinput, UI_SET_KEYBIT, KEY_RIGHTCTRL);
     ioctl(fd_uinput, UI_SET_KEYBIT, KEY_LEFTALT);
@@ -238,6 +229,8 @@ int setup_uinput() {
     ioctl(fd_uinput, UI_SET_KEYBIT, KEY_LEFTSHIFT);
     ioctl(fd_uinput, UI_SET_KEYBIT, KEY_RIGHTSHIFT);
     ioctl(fd_uinput, UI_SET_KEYBIT, KEY_LEFTMETA);
+    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_BACKSPACE);
+    ioctl(fd_uinput, UI_SET_KEYBIT, KEY_V);
 
     struct uinput_setup setup = {0};
     setup.id.bustype = BUS_USB;
@@ -265,8 +258,6 @@ int setup_socket() {
         return -1;
     }
 
-    // Use abstract namespace socket (Linux-specific)
-    // First byte is null, no filesystem entry, kernel manages lifecycle
     struct sockaddr_un addr = {.sun_family = AF_UNIX};
     addr.sun_path[0] = '\0';
     strncpy(addr.sun_path + 1, "xhisper_socket", sizeof(addr.sun_path) - 2);
@@ -283,9 +274,12 @@ int setup_socket() {
     return 0;
 }
 
-// Daemon mode
-int run_daemon() {
+int run_daemon(const char *layout, const char *variant) {
     atexit(cleanup);
+
+    if (build_char_map(layout, variant) < 0) {
+        return 1;
+    }
 
     if (setup_uinput() < 0) {
         return 1;
@@ -329,7 +323,6 @@ int run_daemon() {
     return 0;
 }
 
-// Client mode
 void show_usage() {
     fprintf(stderr,
         "Usage:\n"
@@ -347,7 +340,9 @@ void show_usage() {
         "  xhispertool super            - Press super (Windows key)\n"
         "\n"
         "Daemon:\n"
-        "  xhispertoold                 - Run daemon (or xhispertool --daemon)\n"
+        "  xhispertoold [--layout <code>] [--variant <code>]\n"
+        "                               - Run daemon with optional layout override\n"
+        "                                 (auto-detects from XKB_DEFAULT_LAYOUT if omitted)\n"
     );
 }
 
@@ -363,7 +358,6 @@ int run_client(int argc, char *argv[]) {
         return 1;
     }
 
-    // Use abstract namespace socket (same as daemon)
     struct sockaddr_un addr = {.sun_family = AF_UNIX};
     addr.sun_path[0] = '\0';
     strncpy(addr.sun_path + 1, "xhisper_socket", sizeof(addr.sun_path) - 2);
@@ -445,12 +439,22 @@ int run_client(int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-    // Detect mode: daemon or client
     char *prog = basename(argv[0]);
 
-    if (strcmp(prog, "xhispertoold") == 0 ||
-        (argc > 1 && strcmp(argv[1], "--daemon") == 0)) {
-        return run_daemon();
+    int is_daemon = (strcmp(prog, "xhispertoold") == 0);
+    if (!is_daemon && argc > 1 && strcmp(argv[1], "--daemon") == 0)
+        is_daemon = 1;
+
+    if (is_daemon) {
+        const char *layout = NULL;
+        const char *variant = NULL;
+        for (int i = 1; i < argc; i++) {
+            if (strcmp(argv[i], "--layout") == 0 && i + 1 < argc)
+                layout = argv[++i];
+            else if (strcmp(argv[i], "--variant") == 0 && i + 1 < argc)
+                variant = argv[++i];
+        }
+        return run_daemon(layout, variant);
     } else {
         return run_client(argc, argv);
     }


### PR DESCRIPTION
## Summary

- Replace the hardcoded US QWERTY keycode map with a dynamic one built at startup using **libxkbcommon**, so punctuation is typed correctly on any keyboard layout (Italian, German, French, etc.) without per-layout code.
- The daemon auto-detects the layout from `localectl`, `XKB_DEFAULT_LAYOUT`, or `/etc/default/keyboard`, with an optional `keyboard-layout` config override in `xhisperrc`.
- Adds AltGr modifier support (needed by many European layouts for characters like `@`, `#`, `[`, `]`).

## Changes

- **xhispertool.c**: `build_char_map()` iterates the XKB keymap to discover which keycode + modifiers produce each ASCII character. `type_char()` now presses Shift/AltGr as needed. `setup_uinput()` registers only the discovered keycodes. Daemon accepts `--layout` / `--variant` flags.
- **xhisper.sh**: Auto-detects layout before starting daemon; passes `--layout` / `--variant` flags. New `keyboard-layout` and `keyboard-variant` config keys.
- **Makefile**: Links against `libxkbcommon` via `pkg-config`.
- **default_xhisperrc**: Documents `keyboard-layout` and `keyboard-variant` options.
- **README.md**: Adds `libxkbcommon` to dependency lists; updates keyboard layout documentation.

## Test plan

- [ ] Build with `make clean && make` on a system with `libxkbcommon-dev` installed
- [ ] Run `xhispertoold --layout it` and verify "keymap loaded (layout: it)" in output
- [ ] Run `xhispertoold` without flags on a system with Italian layout configured — verify auto-detection from `localectl`
- [ ] Dictate text containing punctuation (`.`, `?`, `!`, `,`, `:`, `'`) on Italian layout — verify correct characters
- [ ] Dictate on US layout — verify no regression
- [ ] Test AltGr characters (`@`, `#`, `[`, `]`) on Italian layout


Made with [Cursor](https://cursor.com)