### PR TITLE
fix: clipboard never updated on X11 when wl-copy is installed

### DIFF
--- a/xhisper.sh
+++ b/xhisper.sh
@@ -118,13 +118,21 @@ if ! command -v "$XHISPERTOOL" &> /dev/null; then
     exit 1
 fi
 
-# Detect clipboard tool
-if command -v wl-copy &> /dev/null; then
+# Detect clipboard tool. Prefer wl-copy only on Wayland — on X11 wl-copy has no
+# display to talk to and silently fails to update the clipboard, which then makes
+# the non-ASCII paste path re-paste whatever was there before.
+# Also: define CLIP_COPY/CLIP_PASTE as variables, not functions — `$CLIP_COPY`
+# expansion in a pipe requires the variable form (the function form expands to
+# empty string, causing the pipe to silently drop the data).
+if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy &> /dev/null; then
     CLIP_COPY="wl-copy"
     CLIP_PASTE="wl-paste"
 elif command -v xclip &> /dev/null; then
-    CLIP_COPY() { xclip -selection clipboard; }
-    CLIP_PASTE() { xclip -o -selection clipboard; }
+    CLIP_COPY="xclip -selection clipboard"
+    CLIP_PASTE="xclip -o -selection clipboard"
+elif command -v wl-copy &> /dev/null; then
+    CLIP_COPY="wl-copy"
+    CLIP_PASTE="wl-paste"
 else
     echo "Error: No clipboard tool found. Install wl-clipboard or xclip." >&2
     exit 1


### PR DESCRIPTION
## Summary

Two related bugs in the clipboard detection/invocation that together break the non-ASCII paste path on X11 systems where both `wl-clipboard` and `xclip` are installed:

1. **Wrong tool picked on X11.** `command -v wl-copy` succeeds as soon as the binary is on PATH — even when the session is X11. `wl-copy` then has no Wayland display to talk to and silently drops the data, so the X11 clipboard never changes and `Ctrl+V` pastes whatever was there before. Fix: prefer `wl-copy` only when `WAYLAND_DISPLAY` is set, otherwise fall through to `xclip`.

2. **`$CLIP_COPY` expands to empty in the xclip branch.** The xclip branch defined `CLIP_COPY` as a shell function, but it's invoked via `echo … | $CLIP_COPY` in a pipe. Bash expands `$CLIP_COPY` as a variable lookup — since only the function exists, the expansion is an empty string, and the pipe reduces to `echo | ` with no reader. The `echo` side dies with SIGPIPE and the data is silently dropped. Fix: define `CLIP_COPY`/`CLIP_PASTE` as variables holding the command line, matching the `wl-copy` branch.

## Test plan

- [x] On X11 with both `wl-clipboard` and `xclip` installed: `echo "hi" | \$CLIP_COPY` now populates the clipboard (previously did not)
- [x] Dictating text containing non-ASCII characters (e.g. umlauts) correctly inserts them at the cursor
- [ ] On Wayland: `wl-copy` branch still selected and works as before (same code path, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)