### PR TITLE
feat: add `language` rc option to force transcription language

### DIFF
--- a/default_xhisperrc
+++ b/default_xhisperrc
@@ -5,6 +5,8 @@
 # Transcription Settings:
 long-recording-threshold : 1000
 transcription-prompt     : ""
+# language: ISO-639-1 code (e.g., de, en, fr). Empty = auto-detect.
+language                 : ""
 
 # Paste Timing (seconds):
 non-ascii-initial-delay : 0.15 # Increase this if first character comes out wrong.

--- a/xhisper.sh
+++ b/xhisper.sh
@@ -7,6 +7,7 @@
 # Configuration (see default_xhisperrc or ~/.config/xhisper/xhisperrc):
 # - long-recording-threshold : threshold for using large vs turbo model (seconds)
 # - transcription-prompt : context words for better Whisper accuracy
+# - language : ISO-639-1 code to force transcription language (e.g., de); empty = auto-detect
 # - silence-threshold : max volume in dB to consider silent (e.g., -50)
 # - silence-percentage : percentage of recording that must be silent (e.g., 95)
 # - non-ascii-initial-delay : sleep after first non-ASCII paste (seconds)
@@ -68,6 +69,7 @@ PROCESS_PATTERN="pw-record.*$RECORDING"
 # Default configuration
 long_recording_threshold=1000
 transcription_prompt=""
+language=""
 silence_threshold=-50
 silence_percentage=95
 non_ascii_initial_delay=0.1
@@ -88,6 +90,7 @@ if [ -f "$CONFIG_FILE" ]; then
     case "$key" in
       long-recording-threshold) long_recording_threshold="$value" ;;
       transcription-prompt) transcription_prompt="$value" ;;
+      language) language="$value" ;;
       silence-threshold) silence_threshold="$value" ;;
       silence-percentage) silence_percentage="$value" ;;
       non-ascii-initial-delay) non_ascii_initial_delay="$value" ;;
@@ -209,12 +212,16 @@ transcribe() {
   local is_long_recording=$(echo "$(get_duration "$recording") > $long_recording_threshold" | bc -l)
   local model=$([[ $is_long_recording -eq 1 ]] && echo "whisper-large-v3" || echo "whisper-large-v3-turbo")
 
+  local language_args=()
+  [ -n "$language" ] && language_args=(-F "language=$language")
+
   local transcription=$(curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" \
     -H "Authorization: Bearer $GROQ_API_KEY" \
     -H "Content-Type: multipart/form-data" \
     -F "file=@$recording" \
     -F "model=$model" \
     -F "prompt=$transcription_prompt" \
+    "${language_args[@]}" \
     | jq -r '.text' | sed 's/^ //') # Transcription always returns a leading space, so remove it via sed
 
   logging_end_and_write_to_logfile "Transcription" "$transcription" "$logging_start"


### PR DESCRIPTION
## Summary

Whisper auto-detects the input language, which occasionally misfires on short utterances — e.g. dictating a single German word sometimes comes back transcribed in English. Add an optional `language` key to `xhisperrc` that takes an ISO-639-1 code (`de`, `en`, `fr`, …); when set, it's forwarded to Groq's transcription endpoint as the `language` parameter.

Empty (the default) preserves the existing auto-detect behavior, so nothing changes for current users.

Example:
```
language : "de"
```

## Test plan

- [x] With `language : "de"` set, short German utterances consistently transcribe in German
- [x] With `language : ""` (default), auto-detection still works
- [ ] Invalid ISO codes result in a Groq API error visible in `xhisper --log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)