### PR TITLE
feat: add `paste-mode` rc option for clipboard-only paste

### DIFF
--- a/default_xhisperrc
+++ b/default_xhisperrc
@@ -5,7 +5,9 @@
 # Transcription Settings:
 long-recording-threshold : 1000
 transcription-prompt     : ""
-# paste-mode: "type" (layout-sensitive, keeps clipboard) or "clipboard" (always paste, overwrites clipboard)
+# paste-mode: "type" (layout-sensitive, keeps clipboard),
+#             "clipboard" (always paste via clipboard, overwrites clipboard), or
+#             "clipboard-restore" (like clipboard, but saves and restores previous clipboard content)
 paste-mode               : "type"
 
 # Paste Timing (seconds):

--- a/default_xhisperrc
+++ b/default_xhisperrc
@@ -5,6 +5,8 @@
 # Transcription Settings:
 long-recording-threshold : 1000
 transcription-prompt     : ""
+# paste-mode: "type" (layout-sensitive, keeps clipboard) or "clipboard" (always paste, overwrites clipboard)
+paste-mode               : "type"
 
 # Paste Timing (seconds):
 non-ascii-initial-delay : 0.15 # Increase this if first character comes out wrong.

--- a/xhisper.sh
+++ b/xhisper.sh
@@ -7,7 +7,8 @@
 # Configuration (see default_xhisperrc or ~/.config/xhisper/xhisperrc):
 # - long-recording-threshold : threshold for using large vs turbo model (seconds)
 # - transcription-prompt : context words for better Whisper accuracy
-# - paste-mode : "type" (default, layout-sensitive, keeps clipboard) or "clipboard" (always paste, overwrites clipboard)
+# - paste-mode : "type" (default, layout-sensitive, keeps clipboard), "clipboard" (always paste, overwrites clipboard),
+#                or "clipboard-restore" (like clipboard, but saves and restores previous clipboard content)
 # - silence-threshold : max volume in dB to consider silent (e.g., -50)
 # - silence-percentage : percentage of recording that must be silent (e.g., 95)
 # - non-ascii-initial-delay : sleep after first non-ASCII paste (seconds)
@@ -142,13 +143,18 @@ press_wrap_key() {
 paste() {
   local text="$1"
 
-  # Clipboard mode: send entire text in one paste (layout-independent, fast).
-  # Overwrites the clipboard and requires Ctrl+V to work in the target app
-  # (terminals typically need Ctrl+Shift+V — see README Troubleshooting).
-  if [ "$paste_mode" = "clipboard" ]; then
+  # Clipboard modes: send entire text in one paste (layout-independent, fast).
+  # Requires Ctrl+V to work in the target app (terminals need Ctrl+Shift+V — see README).
+  if [ "$paste_mode" = "clipboard" ] || [ "$paste_mode" = "clipboard-restore" ]; then
+    local old_clipboard=""
+    [ "$paste_mode" = "clipboard-restore" ] && old_clipboard=$($CLIP_PASTE 2>/dev/null || true)
     echo -n "$text" | $CLIP_COPY
     sleep "$non_ascii_initial_delay"  # Wait for clipboard tool to populate the selection before pasting
     "$XHISPERTOOL" paste
+    if [ "$paste_mode" = "clipboard-restore" ]; then
+      sleep "$non_ascii_initial_delay"  # Brief pause before restoring to avoid a race with the paste landing
+      echo -n "$old_clipboard" | $CLIP_COPY
+    fi
     return
   fi
 

--- a/xhisper.sh
+++ b/xhisper.sh
@@ -84,9 +84,9 @@ if [ -f "$CONFIG_FILE" ]; then
     [[ "$key" =~ ^[[:space:]]*# ]] && continue
     [[ -z "$key" ]] && continue
 
-    # Trim whitespace and quotes
+    # Trim whitespace, inline comments, and surrounding quotes
     key=$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/^"//;s/"$//')
+    value=$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]\+#.*$//;s/[[:space:]]*$//;s/^"//;s/"$//')
 
     case "$key" in
       long-recording-threshold) long_recording_threshold="$value" ;;
@@ -122,13 +122,17 @@ if ! command -v "$XHISPERTOOL" &> /dev/null; then
     exit 1
 fi
 
-# Detect clipboard tool
-if command -v wl-copy &> /dev/null; then
+# Detect clipboard tool. Prefer wl-copy only on Wayland — on X11 wl-copy has no
+# display to talk to and silently fails to update the clipboard.
+if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy &> /dev/null; then
     CLIP_COPY="wl-copy"
     CLIP_PASTE="wl-paste"
 elif command -v xclip &> /dev/null; then
-    CLIP_COPY() { xclip -selection clipboard; }
-    CLIP_PASTE() { xclip -o -selection clipboard; }
+    CLIP_COPY="xclip -selection clipboard"
+    CLIP_PASTE="xclip -o -selection clipboard"
+elif command -v wl-copy &> /dev/null; then
+    CLIP_COPY="wl-copy"
+    CLIP_PASTE="wl-paste"
 else
     echo "Error: No clipboard tool found. Install wl-clipboard or xclip." >&2
     exit 1

--- a/xhisper.sh
+++ b/xhisper.sh
@@ -7,6 +7,7 @@
 # Configuration (see default_xhisperrc or ~/.config/xhisper/xhisperrc):
 # - long-recording-threshold : threshold for using large vs turbo model (seconds)
 # - transcription-prompt : context words for better Whisper accuracy
+# - paste-mode : "type" (default, layout-sensitive, keeps clipboard) or "clipboard" (always paste, overwrites clipboard)
 # - silence-threshold : max volume in dB to consider silent (e.g., -50)
 # - silence-percentage : percentage of recording that must be silent (e.g., 95)
 # - non-ascii-initial-delay : sleep after first non-ASCII paste (seconds)
@@ -68,6 +69,7 @@ PROCESS_PATTERN="pw-record.*$RECORDING"
 # Default configuration
 long_recording_threshold=1000
 transcription_prompt=""
+paste_mode="type"
 silence_threshold=-50
 silence_percentage=95
 non_ascii_initial_delay=0.1
@@ -88,6 +90,7 @@ if [ -f "$CONFIG_FILE" ]; then
     case "$key" in
       long-recording-threshold) long_recording_threshold="$value" ;;
       transcription-prompt) transcription_prompt="$value" ;;
+      paste-mode) paste_mode="$value" ;;
       silence-threshold) silence_threshold="$value" ;;
       silence-percentage) silence_percentage="$value" ;;
       non-ascii-initial-delay) non_ascii_initial_delay="$value" ;;
@@ -138,6 +141,17 @@ press_wrap_key() {
 
 paste() {
   local text="$1"
+
+  # Clipboard mode: send entire text in one paste (layout-independent, fast).
+  # Overwrites the clipboard and requires Ctrl+V to work in the target app
+  # (terminals typically need Ctrl+Shift+V — see README Troubleshooting).
+  if [ "$paste_mode" = "clipboard" ]; then
+    echo -n "$text" | $CLIP_COPY
+    sleep "$non_ascii_initial_delay"  # Wait for clipboard tool to populate the selection before pasting
+    "$XHISPERTOOL" paste
+    return
+  fi
+
   press_wrap_key
   # Type character by character
   # Use xhispertool type for ASCII (32-126), clipboard+paste for Unicode


### PR DESCRIPTION
## Summary

The default paste mode types ASCII characters directly via uinput — fast, but layout-sensitive: under QWERTZ (and other non-QWERTY layouts), `z` and `y` swap because `xhispertool` assumes QWERTY scancodes. The existing workaround is a QWERTY-toggle modifier via `--rightalt`/`--super`/etc., which requires extra system setup (a second keyboard layout plus a toggle key in the DE).

This PR adds an opt-in `paste-mode : "clipboard"` rc option that sends the entire transcription through the clipboard in a single paste, bypassing per-character typing entirely. Layout-independent, faster, and requires no system setup. Trade-offs:

- Overwrites the user's clipboard
- Relies on `Ctrl+V` working in the target app — terminals typically require `Ctrl+Shift+V`, which is already documented as a limitation in the README

Default (`"type"`) preserves existing behavior.

Example:
```
paste-mode : "clipboard"
```

## Dependency note

On X11 systems, this feature depends on #9 to work correctly — without that fix, `$CLIP_COPY` silently drops the data and the clipboard is never updated. Worth mentioning in case review order matters.

## Test plan

- [x] With `paste-mode : "clipboard"`: dictating under QWERTZ layout produces correct text (no z/y swap)
- [x] With `paste-mode : "type"` (default): existing per-char behavior unchanged
- [x] Clipboard is actually overwritten with the transcription
- [ ] Works in non-terminal apps (editors, browsers, chat, etc.); terminal needs `Ctrl+Shift+V` (expected, documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)